### PR TITLE
Fixes template for RRD_STORAGE_TYPE = MULTIPLE

### DIFF
--- a/pnp4nagios/templates/check_cpu.php
+++ b/pnp4nagios/templates/check_cpu.php
@@ -44,8 +44,8 @@ $opt[1] = sprintf('-T 55 -l 0 --vertical-label "%s" --title "%s / CPU Usage"', $
 $def[1] = '';
 $ds_name[1] = 'CPU Usage';
 
-foreach ($DS as $i) {
-    $def[1] .= rrd::def("var$i", $rrdfile, $DS[$i], 'AVERAGE');
+foreach ($DS as $i => $j) {
+    $def[1] .= rrd::def("var$i", $RRDFILE[$i], $DS[$i], 'AVERAGE');
 
     if ($i == '1') {
         $def[1] .= rrd::area ("var$i", $colors[$i-1], rrd::cut(ucfirst($NAME[$i]), 15));
@@ -63,8 +63,8 @@ $opt[2] = sprintf('-T 55 -l 0 --vertical-label "%s" --title "%s / CPU Usage (san
 $def[2] = '';
 $ds_name[2] = 'CPU Usage (sans idle)';
 
-foreach ($DS as $i) {
-    $def[2] .= rrd::def("var$i", $rrdfile, $DS[$i], 'AVERAGE');
+foreach ($DS as $i => $j) {
+    $def[2] .= rrd::def("var$i", $RRDFILE[$i], $DS[$i], 'AVERAGE');
 
     if($i == 4)
         continue;


### PR DESCRIPTION
With MULTIPLE, an error (trying to reuse vname var1) is thrown when the rrd is rendered. Previously the template was depending on the index in the array being the same as the value; this is true when multiple dimensions are stored in the same .rrd file (RRD_STORAGE_TYPE = SINGLE); however with MULTIPLE; there is a .rrd per dimension, meaning that the value is no longer unique; only the key is
