### PR TITLE
added guest_nice stat

### DIFF
--- a/plugins/check_cpu
+++ b/plugins/check_cpu
@@ -39,7 +39,7 @@ my $np = Nagios::Plugin->new(
 $np->getopts;
 
 
-my @keys = qw/user nice system idle iowait irq softirq steal guest/;
+my @keys = qw/user nice system idle iowait irq softirq steal guest guest_nice/;
 my %results;
 
 foreach my $key(@keys) {
@@ -62,9 +62,8 @@ foreach my $line(@lines) {
 foreach my $key(@keys) {
     $np->add_perfdata(
         label => $key,
-        value => $results{$key} 
+        value => $results{$key}
     );
 }
 
 $np->nagios_exit('OK', '');
-


### PR DESCRIPTION
If you run on latest EL7 you will see an error "Use of uninitialized value within @keys in hash element at ./check_cpu line 57.".

Which is because the guest_nice stat was not defined in keys.